### PR TITLE
Make it possible to use IndexedDBShim directly with NPM through browserify

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+src
+test
+examples
+Gruntfile.js
+travis.sh

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bugs": {
     "url": "https://github.com/axemclion/IndexedDBShim/issues"
   },
-  "main": "grunt.js",
+  "main": "dist/IndexedDBShim.js",
   "keywords": [
     "indexedDB",
     "database",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "IndexedDBShim",
+  "name": "indexeddbshim",
   "version": "0.1.2",
   "author": "Parashuram <code@nparashuram.com>",
   "description": "A polyfill for IndexedDB using WebSql",


### PR DESCRIPTION
This fix doesn't break anything and actually fix the `main` attribute of the `package.json` file which presently points to a non-existing file.

And it makes it possible to use `IndexedDBShim` through NPM simply by doing:

```
$ npm install git://github.com/axemclion/IndexedDBShim.git#commit-ish
```

And if you feel like it, you could even publish this module on NPM registry. That would be even easier for your users:

```
$ npm install indexeddbshim
```

I have preferred to use an all-lower-case package name because this is the common best practice for module names. 

For the record, how to use browserify is described in details in https://github.com/substack/browserify-handbook

After those modifications there might still be things to tweak to improve the experience with NPM but that's the main starting point.

Cheers and I hope you will accept it
