### PR TITLE
close connection so test can continue to execute in Mobile Safari

### DIFF
--- a/test/ObjectStoreTests.js
+++ b/test/ObjectStoreTests.js
@@ -52,6 +52,7 @@ queuedAsyncTest("Reopening an Object Store", function(){
         var transaction = db.transaction([DB.OBJECT_STORE_1], "readonly");
         var objectStore = transaction.objectStore(DB.OBJECT_STORE_1);
         equal(objectStore.autoIncrement, false, "AutoIncrement defaults to false");
+        dbOpenRequest.result.close();
         start();
         nextTest();
     };


### PR DESCRIPTION
My apologies.

I recently contributed this test but missed a line to close the connection. 
see: https://github.com/axemclion/IndexedDBShim/commit/7582c1d195af4976b806674e63d63688a84ec72d

The result is that Mobile Safari will not continue running the next set of tests because it's blocked by the open connection. Chrome, however, seems to be unphased by this.
