### PR TITLE
when encoding key that is null, return null

### DIFF
--- a/src/Key.js
+++ b/src/Key.js
@@ -432,7 +432,7 @@
 
     idbModules.Key = {
         encode: function(key, inArray) {
-            if (key === undefined) {
+            if (key === undefined || key === null) {
                 return null;
             }
             return types[getType(key)].encode(key, inArray);


### PR DESCRIPTION
ran into this problem when having a key that can be null.
