### PR TITLE
Introduced useInMemoryDatabases configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ browser, particularly if one changes the defaults.
     the escaped filename exceeds the length of 254 characters (the shortest
     typical modern file length maximum). Provide a number to change the
     limit or supply `false` to disable any length checking.
+- __useInMemoryDatabases__ - If set to `true` will only create in-memory instead of file-based databases.
 
 The following config items are for Node only and are mostly for development
 debugging.

--- a/src/CFG.js
+++ b/src/CFG.js
@@ -56,6 +56,9 @@ const CFG = {};
         // (characters nevertheless commonly reserved in modern, Unicode-supporting
         // systems): 0x00-0x1F 0x7F " * / : < > ? \ |
     'databaseNameLengthLimit', // Defaults to 254 (shortest typical modern file length limit)
+    // Forces all databases to be stored in memory;
+    //   eliminates the need for database names
+    'useInMemoryDatabases', // Effectively defaults to false (ignored unless true)
 
     // Optional Node WebSQL config
     'sqlBusyTimeout', // Defaults to 1000

--- a/src/IDBFactory.js
+++ b/src/IDBFactory.js
@@ -24,7 +24,7 @@ function createSysDB (success, failure) {
     if (sysdb) {
         success();
     } else {
-        sysdb = CFG.win.openDatabase('__sysdb__.sqlite', 1, 'System Database', CFG.DEFAULT_DB_SIZE);
+        sysdb = CFG.win.openDatabase(CFG.useInMemoryDatabases ? ':memory:' : '__sysdb__.sqlite', 1, 'System Database', CFG.DEFAULT_DB_SIZE);
         sysdb.transaction(function (systx) {
             systx.executeSql('CREATE TABLE IF NOT EXISTS dbVersions (name VARCHAR(255), version INT);', [], success, sysDbCreateError);
         }, sysDbCreateError);

--- a/src/util.js
+++ b/src/util.js
@@ -40,6 +40,9 @@ function sqlQuote (arg) {
 }
 
 function escapeDatabaseNameForSQLAndFiles (db) {
+    if (CFG.useInMemoryDatabases) {
+        return ':memory:';
+    }
     if (CFG.escapeDatabaseName) {
         // We at least ensure NUL is escaped by default, but we need to still
         //   handle empty string and possibly also length (potentially


### PR DESCRIPTION
This PR introduces a configuration option that stores all databases in memory. While it is already possible to use `escapeDatabaseName` to make it work for individual databases, sysdb will still be file-based. Our main use case for it is for running tests to avoid having to do unnecessary file cleanup afterwards.

I also noticed that #278 mentions that you intend to make it easier for Node users to use in-memory databases which this change might help with.

If it's a concern to you that this option would be exposed to non-Node environments, I could clarify this in the comments/README or implement it differently. For instance, extending `escapeDatabaseName()` to also apply to sysdb or adding a separate configuration option to escape the file name of sysdb.