### PR TITLE
Order results correctly when using getAll() and getAllKeys()

### DIFF
--- a/src/IDBIndex.js
+++ b/src/IDBIndex.js
@@ -652,7 +652,7 @@ function buildFetchIndexDataSQL (nullDisallowed, index, range, opType, multiChec
         }
     }
     if (opType !== 'count') {
-        sql.push('ORDER BY ', util.escapeIndexNameForSQL(index.name));
+        sql.push('ORDER BY', util.escapeIndexNameForSQL(index.name), ',', util.sqlQuote('key'));
     }
     return [nullDisallowed, index, hasRange, range, opType, multiChecks, sql, sqlValues];
 }

--- a/src/IDBIndex.js
+++ b/src/IDBIndex.js
@@ -651,6 +651,9 @@ function buildFetchIndexDataSQL (nullDisallowed, index, range, opType, multiChec
             setSQLForKeyRange(convertedRange, util.escapeIndexNameForSQL(index.name), sql, sqlValues, true, false);
         }
     }
+    if (opType !== 'count') {
+        sql.push('ORDER BY ', util.escapeIndexNameForSQL(index.name));
+    }
     return [nullDisallowed, index, hasRange, range, opType, multiChecks, sql, sqlValues];
 }
 


### PR DESCRIPTION
This will hopefully resolve the ordering issue listed in
https://github.com/dfahlander/Dexie.js/issues/709

https://github.com/dfahlander/Dexie.js/issues/701

as referred from https://github.com/axemclion/IndexedDBShim/issues/325.

