### PR TITLE
fix: release finished transactions from IDBDatabase.__transactions

### DIFF
--- a/src/IDBTransaction.js
+++ b/src/IDBTransaction.js
@@ -56,7 +56,7 @@ const readonlyProperties = ['objectStoreNames', 'mode', 'durability', 'db', 'err
  *   __requestsFinished: boolean,
  *   __transFinishedCb: (err: boolean, cb: ((bool?: boolean) => void)) => void,
  *   __callTransFinishedCb: (err: boolean, cb: ((bool?: boolean) => void)) => void,
- *   __transactionEndCallback: () => void,
+ *   __transactionEndCallback: (() => void)|undefined,
  *   __transactionFinished: boolean,
  *   __completed: boolean,
  *   __transFinishedCbFired: boolean,
@@ -90,6 +90,19 @@ const readonlyProperties = ['objectStoreNames', 'mode', 'durability', 'db', 'err
  *   __assertWritable: () => void,
  * }} IDBTransactionFull
  */
+
+/**
+ * @param {IDBTransactionFull} tx
+ * @returns {void}
+ */
+function releaseFinishedTransaction (tx) {
+    const pos = tx.db.__transactions.indexOf(tx);
+    if (pos !== -1) {
+        tx.db.__transactions.splice(pos, 1);
+    }
+    tx.__transactionEndCallback = undefined;
+    tx.__requests = [];
+}
 
 /**
  * The IndexedDB Transaction.
@@ -645,6 +658,7 @@ IDBTransaction.prototype.__executeRequests = function () {
             } finally {
                 activeTransactions.delete(me);
                 me.__storeHandles = {};
+                releaseFinishedTransaction(me);
             }
         }
         if (me.mode === 'readwrite' || me.mode === 'readonly') {
@@ -928,6 +942,7 @@ IDBTransaction.prototype.__abortTransaction = function (err) {
                 me.dispatchEvent(evt);
                 me.__storeHandles = {};
                 me.dispatchEvent(createEvent('__abort'));
+                releaseFinishedTransaction(me);
             }, 0);
             return undefined;
         }).catch((err) => {

--- a/tests-mocha/IDBTransaction/retention-spec.js
+++ b/tests-mocha/IDBTransaction/retention-spec.js
@@ -1,0 +1,94 @@
+describe('IDBTransaction retention', function () {
+    'use strict';
+
+    /**
+     * Runs assertions off the event loop, reporting any failure through
+     *   `done` rather than throwing into a `setTimeout`, which this suite's
+     *   `window.onerror` shim turns into unbounded recursion.
+     * @param {IDBDatabase} db
+     * @param {() => void} done
+     * @param {() => void} assertions
+     * @returns {void}
+     */
+    function assertLater (db, done, assertions) {
+        setTimeout(function () {
+            let error = null;
+            try {
+                assertions();
+            } catch (err) {
+                error = err;
+            }
+            db.close();
+            done(error);
+        }, 0);
+    }
+
+    it('should remove a completed transaction from the connection', function (done) {
+        util.createDatabase('inline', function (err, db) {
+            if (err) {
+                expect(function () { throw err; }).to.not.throw(Error);
+                done();
+                return;
+            }
+            const tx = db.transaction('inline', 'readwrite');
+            tx.objectStore('inline').put({id: 1, name: 'John Doe'});
+
+            tx.oncomplete = function () {
+                assertLater(db, done, function () {
+                    expect(db.__transactions).to.not.include(tx);
+                    expect(tx.__requests).to.have.lengthOf(0);
+                });
+            };
+        });
+    });
+
+    it('should remove an aborted transaction from the connection', function (done) {
+        util.createDatabase('inline', function (err, db) {
+            if (err) {
+                expect(function () { throw err; }).to.not.throw(Error);
+                done();
+                return;
+            }
+            const tx = db.transaction('inline', 'readwrite');
+            tx.objectStore('inline').put({id: 1, name: 'John Doe'});
+
+            tx.onabort = function () {
+                assertLater(db, done, function () {
+                    expect(db.__transactions).to.not.include(tx);
+                    expect(tx.__requests).to.have.lengthOf(0);
+                });
+            };
+            tx.abort();
+        });
+    });
+
+    it('should not accumulate transactions on a long-lived connection', function (done) {
+        util.createDatabase('inline', function (err, db) {
+            if (err) {
+                expect(function () { throw err; }).to.not.throw(Error);
+                done();
+                return;
+            }
+            let remaining = 5;
+
+            /**
+             * @returns {void}
+             */
+            function next () {
+                if (remaining === 0) {
+                    assertLater(db, done, function () {
+                        expect(db.__transactions).to.have.lengthOf(0);
+                    });
+                    return;
+                }
+                remaining--;
+                const tx = db.transaction('inline', 'readwrite');
+                tx.objectStore('inline').put({id: remaining, name: 'John Doe'});
+                tx.oncomplete = function () {
+                    setTimeout(next, 0);
+                };
+            }
+            next();
+        });
+    });
+});

--- a/tests-mocha/index.html
+++ b/tests-mocha/index.html
@@ -109,6 +109,7 @@
     <script src="IDBTransaction/events-spec.js"></script>
     <script src="IDBTransaction/objectStore-spec.js"></script>
     <script src="IDBTransaction/durability-spec.js"></script>
+    <script src="IDBTransaction/retention-spec.js"></script>
 
     <script>
       mocha.run();

--- a/tests-mocha/test-node.js
+++ b/tests-mocha/test-node.js
@@ -94,7 +94,8 @@ if (process.env.npm_config_test) { // eslint-disable-line n/no-process-env -- Co
         'IDBObjectStore/getAll-direction-spec.js',
         'IDBTransaction/objectStore-spec.js',
         'IDBTransaction/events-spec.js',
-        'IDBTransaction/durability-spec.js'
+        'IDBTransaction/durability-spec.js',
+        'IDBTransaction/retention-spec.js'
     ];
 }
 await Promise.all(tests.map(async function (path) {


### PR DESCRIPTION
### The problem

Every transaction is pushed onto `db.__transactions` at creation ([IDBDatabase.js#L306](https://github.com/indexeddbshim/IndexedDBShim/blob/main/src/IDBDatabase.js#L306)), and the array is only cleared when the connection closes — in `close()` and `__forceClose()`. That model is fine for a page that opens a connection, works, and closes it. For an application that holds one connection open for the lifetime of the page, `__transactions` is append-only for the whole session.

A retained transaction is not just a small object. Its `__requests` queue is never emptied after being drained, and each entry's `op` is a closure over the value passed to `put()`/`add()` — see `IDBObjectStore.__storingRecordObjectStore`, where the queued function references `value` directly. So every value ever written stays reachable through the transaction that wrote it.

I hit this in a Capacitor application that keeps a single connection open for the life of the page and writes image data as `ArrayBuffer`s via `put()`. Retained memory grew linearly with the number of transactions, reaching hundreds of MB over a bulk download, until iOS killed the web process.

### The fix

Remove the transaction from `db.__transactions` when it completes or aborts, and drop its end callback and request queue.

Every reader of that array is safe with a finished transaction absent — it exists to abort what is still *running* at close time. There is existing precedent on both counts: `IDBFactory` already performs the same `indexOf`/`splice` for the upgrade transaction on completion, and the `activeTransactions` set is already maintained at exactly these two lifecycle points.

Clearing `__requests` matters independently of the array removal, since an application holding an `IDBRequest` can still reach a finished transaction through it.

`__transactionEndCallback` is widened to `(() => void)|undefined` in the `IDBTransactionFull` typedef. The constructor never initialised it and every read is already truthiness-guarded, so `undefined` is the faithful reset value.

### Tests

`tests-mocha/IDBTransaction/retention-spec.js`, covering the complete path, the abort path, and non-accumulation across repeated transactions on one connection.

These assert on internals (`db.__transactions`, `tx.__requests`), which no existing spec does. I could not find a black-box observable for "the reference was released" — happy to take a different approach if you would prefer one.

`tests-mocha`: 378 passing with the fix; 375 passing and exactly 3 failing without it. `tests-polyfill`, `eslint`, and `tsc` all clean.

One unrelated note: `npm install` and `npm ci` both fail on `main` with an `ERESOLVE` conflict between `@babel/core` and `@rollup/plugin-babel@7.1.0`. I used `--legacy-peer-deps`.
