### PR TITLE
fix: keep the `path` import polyfillable for browser bundlers

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -44,7 +44,7 @@ const babelNodeOptions = {...babelBrowserOptions,
 };
 
 // `rollup-plugin-node-polyfills` only recognizes bare builtin specifiers
-//   (e.g., "path"), not the "node:"-prefixed form used in `src/IDBFactory.js`,
+//   (e.g., "path"), not the "node:"-prefixed form,
 //   so without this, browser bundles get "Unresolved dependencies"/"Missing
 //   shims" warnings for `node:path` instead of being polyfilled.
 const stripNodeProtocol = () => ({

--- a/src/IDBFactory.js
+++ b/src/IDBFactory.js
@@ -1,6 +1,6 @@
 /* eslint-disable sonarjs/no-invariant-returns -- Convenient here */
-// eslint-disable-next-line no-restricted-imports -- Can be polyfilled
-import path from 'node:path';
+// eslint-disable-next-line no-restricted-imports, unicorn/prefer-node-protocol -- Can be polyfilled
+import path from 'path';
 import SyncPromise from 'sync-promise-expanded';
 
 import {createEvent} from './Event.js';


### PR DESCRIPTION
Reverts `src/IDBFactory.js` to the bare `path` specifier. `node:path` cannot be polyfilled by webpack 5, rspack, or `rollup-plugin-node-polyfills`, and `src/` is what consumers bundle.

### Why the prefix breaks consumers

webpack 5 and rspack resolve a `node:`-prefixed request as a URI scheme: `NormalModuleFactory` throws `UnhandledSchemeError` after the `beforeResolve` hook but *before* `resolve.alias` and `resolve.fallback` are consulted, so neither of the usual polyfill mechanisms can reach it. `rollup-plugin-node-polyfills` likewise keys off the bare name.

The browser entry reaches this import (`browser-noninvasive.js` → `setGlobalVars.js` → `IDBFactory.js`), and `exports["."].default.import` points at `src/`, so every consumer bundling the browser build hits it. Downstream this broke an app bundle, an iOS Capacitor bundle, and a Storybook build; the only remedy available to a consumer is rewriting the specifier at `beforeResolve`:

```js
new rspack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
    resource.request = resource.request.replace(/^node:/, "");
});
```

### How it got introduced

17.2.2 used the bare specifier. `2a376f6` ("chore: update typeson-registry, devDeps; lint") changed it to `node:path` as a `unicorn/prefer-node-protocol` autofix; 17.3.0 through 17.7.0 all carry the prefixed form.

It escaped notice because the line already carried `// eslint-disable-next-line no-restricted-imports -- Can be polyfilled`. `no-restricted-imports` restricts *both* spellings (`ash-nazg/bare` lists `builtinModules` and their `node:` forms — 144 entries), so the rewritten import stayed suppressed under the existing directive.

This project's own bundles survived only because `a35ac4b`, the same day, added the `stripNodeProtocol` rollup plugin to undo the prefix at build time — which fixed the artifacts while leaving `src/` broken for everyone bundling it directly.

### The change

- Bare specifier restored, and `unicorn/prefer-node-protocol` added to the existing disable directive so a later `--fix` cannot silently reintroduce the prefix under it.
- `stripNodeProtocol` is kept — a dependency can still import a prefixed builtin — but its comment no longer cites `src/IDBFactory.js`.

`path` has to stay genuinely polyfillable rather than stubbed to `false`: three of the four `path.join` sites build the name handed to `__openDatabase` and do execute in the browser, where WebSQL backs the connection. Only the `fs.unlink` site is `fs`-gated. Node behaviour is unchanged.

### Verification

- `eslint .` clean; `eslint --fix src/IDBFactory.js` leaves the bare specifier intact.
- `rollup -c` clean; all three browser bundles contain zero `node:path` and retain `rollup-plugin-node-polyfills/polyfills/path.js` in the module graph.
- `tests-mocha/test-node.js`: 378 passing.
- No `dist/` churn — `stripNodeProtocol` already normalised the specifier, so bundle output is unaffected.

### Preventing recurrence

The inline directive now names `unicorn/prefer-node-protocol`, so this particular line is safe from `--fix`. But that is a per-line guard, and the failure mode here was exactly that a *neighbouring* suppression made an autofix invisible. Two project-level options, left out of this PR since they are your call:

**1. Turn the autofixable rule off for browser-reachable source**, rather than suppressing it line by line:

```js
{
    files: ['src/*.js'],
    ignores: ['src/node*.js'],
    rules: {'unicorn/prefer-node-protocol': 'off'}
}
```

I tried this locally: the rule resolves to `off` for `src/IDBFactory.js` and stays `error` for `src/node.js` and `src/node-UnicodeIdentifiers.js`, with `eslint .` clean once the then-redundant tag is dropped from the inline directive. It removes the autofixer's ability to reintroduce the prefix anywhere in browser-reachable `src/`, instead of depending on each line carrying the right suppression. Coverage is not reduced: `no-restricted-imports` stays `error` there and still forces a deliberate, described exemption for any *new* builtin import — only the silent-rewrite path is closed.

**2. Consider removing `stripNodeProtocol` entirely.**

With this fix applied the plugin is a no-op. I built with and without it: all four bundles are byte-identical (md5-matched), no `rollup` warnings either way, and `rollup-plugin-node-polyfills/polyfills/path.js` still resolves into the browser graph without it. Nothing in any bundle graph currently uses a `node:` specifier — the only one I found anywhere in the dependency trees is `node:module` in `typeson-registry/polyfills/URL.js`, which the graph does not reach.

Its cost is not neutral. Silently rewriting the specifier is precisely what let the 17.3.0 bundles look healthy for five releases while `src/` was broken for every consumer bundling it. The plugin did not prevent the regression; it hid it.

And it is not needed to keep the situation visible. I simulated the regression with the plugin removed — reintroducing `node:path` in `src/IDBFactory.js` — and `rollup` reports it plainly, naming the file:

```
(!) Missing shims for Node.js built-ins
    Creating a browser bundle that depends on "node:path".
(!) Unresolved dependencies
    node:path (imported by "src/IDBFactory.js")
(!) Missing global variable name
    node:path (guessing "path")
```

That is the signal the plugin currently suppresses. The build still exits 0 and emits a bundle, so this is loud rather than fatal — but it is strictly louder than the present behaviour of no warnings and a plausible-looking artifact, and it covers a dependency importing a prefixed builtin just as well as a first-party import.

I have left the plugin in place here, with only its comment updated, since removing it is your call and is not needed for this fix. Happy to drop it from this PR or a follow-up if you agree.

Worth noting for either option: `path` is currently the only Node builtin the browser module graph pulls in at all (`fs` stays out of it via `setFS()` injection), so the surface being guarded is small — the bundle's non-`src/` sources are just `eventtargeter`, `sync-promise-expanded`, `typeson-registry`, and that one polyfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
